### PR TITLE
スタックトレースでファイルやフォルダの場所を実行場所に関係なく特定するコツ

### DIFF
--- a/stacktrace.py
+++ b/stacktrace.py
@@ -1,0 +1,10 @@
+import inspect
+
+# カレントから見て何層下か（ex:3）
+hierarchy = 3
+
+# pythonが実行されている起点に関係なくアクセスしたいパスの位置を入手する
+nowpath = '/'.join(inspect.stack()[0][1].split('/')[:-hierarchy])
+
+# そこから任意の直下フォルダにアクセスしたい場合
+target_path = os.path.join(nowpath, 任意)


### PR DESCRIPTION
これがしたい場面に遭遇しないと意味不明だと思うから例をあとで記載する